### PR TITLE
Find apps via developerId (Android only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 | iOS (single app) - ioki Hamburg | [Link](https://appversions.vercel.app/?ios=ioki-hamburg/id1400408720) | [Link](https://appversions.vercel.app/?ios=ioki-hamburg/id1400408720&format=table) | [Link](https://appversions.vercel.app/?ios=ioki-hamburg/id1400408720&format=json) | 
 | iOS (multiple apps) - ioki Hamburg, ioki Wittlich | [Link](https://appversions.vercel.app/?ios=ioki-hamburg/id1400408720,ioki-wittlich/id1377071496) | [Link](https://appversions.vercel.app/?ios=ioki-hamburg/id1400408720,ioki-wittlich/id1377071496&format=table) | [Link](https://appversions.vercel.app/?ios=ioki-hamburg/id1400408720,ioki-wittlich/id1377071496&format=json) | 
 | Android & iOS (multiple apps) - ioki Hamburg, ioki Wittlich | [Link](https://appversions.vercel.app/?android=com.ioki.hamburg,com.ioki.wittlich&ios=ioki-hamburg/id1400408720,ioki-wittlich/id1377071496) | [Link](https://appversions.vercel.app/?android=com.ioki.hamburg,com.ioki.wittlich&ios=ioki-hamburg/id1400408720,ioki-wittlich/id1377071496&format=table) | [Link](https://appversions.vercel.app/?android=com.ioki.hamburg,com.ioki.wittlich&ios=ioki-hamburg/id1400408720,ioki-wittlich/id1377071496&format=json) | 
+| Android (with Developer ID) - [ioki](https://play.google.com/store/apps/dev?id=8505861851834820244) | [Link](https://appversions.vercel.app/?android=did:8505861851834820244) | [Link](https://appversions.vercel.app/?android=did:8505861851834820244&format=table) | [Link](https://appversions.vercel.app/?android=did:8505861851834820244&format=json) | 
 
 
 ## Formats

--- a/appVersionHelper.go
+++ b/appVersionHelper.go
@@ -14,10 +14,10 @@ func HandleFunc(w http.ResponseWriter, r *http.Request) {
 	iosQuery := r.URL.Query().Get("ios")
 	format := r.URL.Query().Get("format")
 
-	var androidAppIds []string
+	var androidAppOrDevIds []string
 	if androidQuery != "" {
 		for _, androidAppId := range strings.Split(androidQuery, ",") {
-			androidAppIds = append(androidAppIds, strings.TrimSpace(androidAppId))
+			androidAppOrDevIds = append(androidAppOrDevIds, strings.TrimSpace(androidAppId))
 		}
 	}
 
@@ -28,8 +28,8 @@ func HandleFunc(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if len(androidAppIds) > 0 || len(iosAppIds) > 0 {
-		appsInformation := usecase.GetAppsInformation(androidAppIds, iosAppIds)
+	if len(androidAppOrDevIds) > 0 || len(iosAppIds) > 0 {
+		appsInformation := usecase.GetAppsInformation(androidAppOrDevIds, iosAppIds)
 		fmt.Fprint(w, presentation.FormatOutput(format, appsInformation.AndroidApps, appsInformation.IosApps))
 		w.Header().Add("Content-Type", getContentType(format))
 	} else {

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.16
 
 require (
 	github.com/PuerkitoBio/goquery v1.6.1
-	github.com/n0madic/google-play-scraper v0.0.0-20220823094815-fb5b701c5b9a
+	github.com/n0madic/google-play-scraper v0.0.0-20230423092235-0d248506e95b
 )

--- a/go.sum
+++ b/go.sum
@@ -8,10 +8,8 @@ github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/k3a/html2text v1.0.8 h1:rVanLhKilpnJUJs/CNKWzMC4YaQINGxK0rSG8ssmnV0=
 github.com/k3a/html2text v1.0.8/go.mod h1:ieEXykM67iT8lTvEWBh6fhpH4B23kB9OMKPdIBmgUqA=
-github.com/n0madic/google-play-scraper v0.0.0-20220616081454-628764b26b1f h1:yr1qE0L83plGKj/1b7LYLaV6wWjR35guQiOrH8rV5A0=
-github.com/n0madic/google-play-scraper v0.0.0-20220616081454-628764b26b1f/go.mod h1:K/qUIZS0FlcMPrDqbRfY3Z9xIdKvqBiDic76r2E7vX8=
-github.com/n0madic/google-play-scraper v0.0.0-20220823094815-fb5b701c5b9a h1:czqf8H96FyK5T4E+qC+RkuR2Ox7mlNTZns8yQkv/TuA=
-github.com/n0madic/google-play-scraper v0.0.0-20220823094815-fb5b701c5b9a/go.mod h1:K/qUIZS0FlcMPrDqbRfY3Z9xIdKvqBiDic76r2E7vX8=
+github.com/n0madic/google-play-scraper v0.0.0-20230423092235-0d248506e95b h1:t0cYhFsMrkPm8kJFDTYQDC7fk/TfBilqLbeBiZA5asw=
+github.com/n0madic/google-play-scraper v0.0.0-20230423092235-0d248506e95b/go.mod h1:K/qUIZS0FlcMPrDqbRfY3Z9xIdKvqBiDic76r2E7vX8=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=

--- a/usecase/getAndroidInformation.go
+++ b/usecase/getAndroidInformation.go
@@ -2,9 +2,27 @@ package usecase
 
 import (
 	playScraper "github.com/n0madic/google-play-scraper/pkg/app"
+	playScraperDevSearch "github.com/n0madic/google-play-scraper/pkg/developer"
 )
 
 const androidUrlPrefix = "https://play.google.com/store/apps/details?id="
+
+func androidAppIdsFromDeveloperId(devId string) []string {
+	dev := playScraperDevSearch.NewByID(devId, playScraperDevSearch.Options{
+		Country:  "de",
+		Language: "de",
+		Number:   100,
+	})
+	err := dev.Run()
+	if err != nil {
+		return []string{}
+	}
+	appIds := []string{}
+	for _, app := range dev.Results {
+		appIds = append(appIds, app.ID)
+	}
+	return appIds
+}
 
 func androidAppInfo(appId string) App {
 	app := playScraper.New(appId, playScraper.Options{
@@ -13,28 +31,35 @@ func androidAppInfo(appId string) App {
 	})
 	err := app.LoadDetails()
 	if err != nil {
-		return App{
-			Id:       appId,
-			Name:     "",
-			Version:  "",
-			Rating:   "",
-			Url:      androidUrlPrefix + appId,
-			ImageSrc: "",
-			Error:    true,
-		}
+		return createErrorApp(appId)
 	}
+	return createApp(appId, app)
+}
 
+func createApp(appOrPublisherId string, app *playScraper.App) App {
 	nameOk := app.Title != ""
 	versionOk := app.Version != ""
 	ratingOk := app.ScoreText != ""
 	imgOk := app.Icon != ""
 	return App{
-		Id:       appId,
+		Id:       appOrPublisherId,
 		Name:     app.Title,
 		Version:  app.Version,
 		Rating:   app.ScoreText,
-		Url:      androidUrlPrefix + appId,
+		Url:      androidUrlPrefix + appOrPublisherId,
 		ImageSrc: app.Icon,
 		Error:    !(nameOk && versionOk && ratingOk && imgOk),
+	}
+}
+
+func createErrorApp(appId string) App {
+	return App{
+		Id:       appId,
+		Name:     "",
+		Version:  "",
+		Rating:   "",
+		Url:      androidUrlPrefix + appId,
+		ImageSrc: "",
+		Error:    true,
 	}
 }

--- a/usecase/getAndroidInformation.go
+++ b/usecase/getAndroidInformation.go
@@ -36,17 +36,17 @@ func androidAppInfo(appId string) App {
 	return createApp(appId, app)
 }
 
-func createApp(appOrPublisherId string, app *playScraper.App) App {
+func createApp(appId string, app *playScraper.App) App {
 	nameOk := app.Title != ""
 	versionOk := app.Version != ""
 	ratingOk := app.ScoreText != ""
 	imgOk := app.Icon != ""
 	return App{
-		Id:       appOrPublisherId,
+		Id:       appId,
 		Name:     app.Title,
 		Version:  app.Version,
 		Rating:   app.ScoreText,
-		Url:      androidUrlPrefix + appOrPublisherId,
+		Url:      androidUrlPrefix + appId,
 		ImageSrc: app.Icon,
 		Error:    !(nameOk && versionOk && ratingOk && imgOk),
 	}


### PR DESCRIPTION
fixes halfy #12 
At least android search is possible now 🚀 

instead of adding `appIds` we can use `did:[DeveloperId]`.
E.g. for [ioki](https://play.google.com/store/apps/dev?id=8505861851834820244&gl=DE) we can use the `id` `8505861851834820244`.
Query string would be:
`https://appversions-stefma.vercel.app/?android=did:8505861851834820244`

TODO:
- [x] Add example to README


